### PR TITLE
[codex] Optimize primal-dual R updates

### DIFF
--- a/R/ROptimPrimalDual.R
+++ b/R/ROptimPrimalDual.R
@@ -1,6 +1,5 @@
-# Note: box_qp_f is a Fortran routine that must be registered at package load
-# The wrapper function call_box_qp_f (in BoxQP.R) handles parameter type coercion
-# and calls the underlying Fortran routine via .Fortran()
+# The column sweep is implemented in primalDualSweepCpp(); the R wrapper keeps
+# validation, stopping rules, and optional objective tracing in one place.
 
 .dp_pcg_objective <- function(R, S, lambda) {
   chol_R <- chol(R)
@@ -12,7 +11,10 @@
 
 ROptimPrimalDual <-
   function(S, R = NULL, U = NULL, lambda, outer.Maxiter = 100, outer.tol = 10^-5,
-           qp.Maxiter = 1000, qp.tol = 10^-7, obj.seq = FALSE) {
+           qp.Maxiter = 1000, qp.tol = 10^-7, obj.seq = FALSE,
+           stopping.rule = c("hybrid", "max"),
+           track.qp.time = FALSE) {
+    stopping.rule <- match.arg(stopping.rule)
     if (is.null(S)) stop("S is required as input.", call. = FALSE)
     if (!is.matrix(S)) S <- as.matrix(S)
     if (!is.numeric(S)) stop("S should be numeric.", call. = FALSE)
@@ -59,74 +61,101 @@ ROptimPrimalDual <-
 
     if (p == 1) {
       obj.vals <- if (obj.seq) .dp_pcg_objective(R, S, lambda) else NULL
-      result <- list(R = R, U = U, rel.err = 0, sparse.nos = 0, time.counter.QP = c(0, 0, 0))
+      result <- list(
+        R = R, U = U, rel.err = 0, rms.err = 0, sparse.nos = 0,
+        time.counter.QP = c(user = 0, system = 0, elapsed = 0)
+      )
       if (obj.seq) result$obj.vals <- obj.vals
       return(result)
     }
 
-    rel.err <- rep(0, outer.Maxiter)
-    obj.vals <- rep(0, outer.Maxiter)
-    sparse.nos <- rep(0, outer.Maxiter)
-    time.counter.QP <- array(0, dim = c(outer.Maxiter * p, 3))
+    if (!obj.seq && stopping.rule == "max" && !track.qp.time) {
+      opt <- primalDualOuterCpp(
+        S = S,
+        R = R,
+        U = U,
+        lambda = lambda,
+        outerMaxIter = outer.Maxiter,
+        outerTol = outer.tol,
+        qpMaxIter = qp.Maxiter,
+        qpTol = qp.tol
+      )
 
-    ii <- 0
-    tol <- Inf
+      R <- opt$R
+      U <- opt$U
+      diag(R) <- 1
+      if (inherits(try(chol(R), silent = TRUE), "try-error")) {
+        stop("Final R is not positive definite.", call. = FALSE)
+      }
+
+      R_symetric <- (R + t(R)) / 2
+      diag(R_symetric) <- 1
+
+      return(list(
+        R = R,
+        R_symetric = R_symetric,
+        Rinv = NULL,
+        dual_box = U,
+        outer.count = opt$outer.count,
+        time.counter.QP = c(user = 0, system = 0, elapsed = 0),
+        rel.err = opt$rel.err,
+        rms.err = opt$rms.err,
+        sparse.nos = opt$sparse.nos
+      ))
+    }
+
+    max.err <- numeric(0)
+    rms.err <- numeric(0)
+    obj.vals <- numeric(0)
+    sparse.nos <- numeric(0)
+    time.counter.QP <- c(user = 0, system = 0, elapsed = 0)
+    off_diag <- row(R) != col(R)
+    current_obj <- if (obj.seq || stopping.rule == "hybrid") {
+      .dp_pcg_objective(R, S, lambda)
+    } else {
+      NA_real_
+    }
 
     for (outer.iter in seq_len(outer.Maxiter)) {
       R.old <- R
+      old_obj <- current_obj
 
-      for (j in seq_len(p)) {
-        ii <- ii + 1
-        I <- setdiff(seq_len(p), j)
-
-        A <- R[I, I, drop = FALSE]
-        s <- as.numeric(S[I, j])
-
-        U[I, j] <- pmin(lambda, pmax(-lambda, U[I, j]))
-
+      if (track.qp.time) {
         t <- proc.time()
-        obj <- call_box_qp_f(
-          Q = A,
-          u = as.numeric(U[I, j]),
-          b = s,
-          rho = lambda,
-          Maxiter = qp.Maxiter,
-          tol = qp.tol
-        )
-        t <- proc.time() - t
-        time.counter.QP[ii, ] <- as.numeric(c(t[1], t[2], t[3]))
-
-        u <- as.numeric(obj$u)
-        v <- s + u
-        g <- 0.5 * as.numeric(obj$grad_vec)
-
-        tval <- sum(v * g)
-        disc <- 1 + 4 * tval
-        if (disc <= 0) {
-          stop("PCGLASSO block update produced a non-positive discriminant.", call. = FALSE)
-        }
-        omega <- (1 + sqrt(disc)) / 2
-        r <- -g / omega
-
-        R[I, j] <- r
-        R[j, I] <- r
-        R[j, j] <- 1
-
-        U[I, j] <- u
-        U[j, I] <- u
-        U[j, j] <- 0
+        sweep <- primalDualSweepCpp(S, R, U, lambda, qp.Maxiter, qp.tol)
+        time.counter.QP <- time.counter.QP + as.numeric((proc.time() - t)[1:3])
+      } else {
+        sweep <- primalDualSweepCpp(S, R, U, lambda, qp.Maxiter, qp.tol)
       }
+      R <- sweep$R
+      U <- sweep$U
 
       diag(R) <- 1
-      tol <- max(abs(R - R.old)) / max(1, max(abs(R.old)))
-      rel.err[outer.iter] <- tol
-      sparse.nos[outer.iter] <- sum(abs(R[row(R) != col(R)]) <= 10^-9)
-      if (obj.seq) obj.vals[outer.iter] <- .dp_pcg_objective(R, S, lambda)
+      diff_R <- R - R.old
+      max_change <- max(abs(diff_R)) / max(1, max(abs(R.old)))
+      rms_change <- sqrt(mean(diff_R[off_diag]^2))
+      max.err[outer.iter] <- max_change
+      rms.err[outer.iter] <- rms_change
+      sparse.nos[outer.iter] <- sum(abs(R[off_diag]) <= 10^-9)
 
-      if (tol < outer.tol && outer.iter > 1) break
+      if (obj.seq || stopping.rule == "hybrid") {
+        current_obj <- .dp_pcg_objective(R, S, lambda)
+      }
+      if (obj.seq) obj.vals[outer.iter] <- current_obj
+
+      if (outer.iter > 1) {
+        converged <- max_change < outer.tol
+        if (stopping.rule == "hybrid") {
+          objective_change <- abs(current_obj - old_obj) / max(1, abs(old_obj))
+          objective_not_worse <- current_obj <= old_obj + max(outer.tol, 1e-12)
+          max_change_controlled <- max_change < 10 * outer.tol
+          converged <- converged ||
+            (rms_change < outer.tol && objective_change < outer.tol &&
+               objective_not_worse && max_change_controlled)
+        }
+        if (converged) break
+      }
     }
-
-    time.counter.QP <- colSums(time.counter.QP[seq_len(ii), , drop = FALSE])
 
     diag(R) <- 1
     if (inherits(try(chol(R), silent = TRUE), "try-error")) {
@@ -144,8 +173,9 @@ ROptimPrimalDual <-
       dual_box = U,
       outer.count = outer.iter,
       time.counter.QP = time.counter.QP,
-      rel.err = rel.err[seq_len(outer.iter)],
-      sparse.nos = sparse.nos[seq_len(outer.iter)]
+      rel.err = max.err,
+      rms.err = rms.err,
+      sparse.nos = sparse.nos
     )
     if (obj.seq) result$obj.vals <- obj.vals[seq_len(outer.iter)]
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,18 @@ updateLoopCpp <- function(S, Q, Qinv, loglik_s, lambda, tol_inner, max_inner_ite
     .Call(`_pcglassoFast_updateLoopCpp`, S, Q, Qinv, loglik_s, lambda, tol_inner, max_inner_iter)
 }
 
+boxQpCpp <- function(Q, u, b, rho, maxIter, tol) {
+    .Call(`_pcglassoFast_boxQpCpp`, Q, u, b, rho, maxIter, tol)
+}
+
+primalDualSweepCpp <- function(S, R, U, lambda, qpMaxIter, qpTol) {
+    .Call(`_pcglassoFast_primalDualSweepCpp`, S, R, U, lambda, qpMaxIter, qpTol)
+}
+
+primalDualOuterCpp <- function(S, R, U, lambda, outerMaxIter, outerTol, qpMaxIter, qpTol) {
+    .Call(`_pcglassoFast_primalDualOuterCpp`, S, R, U, lambda, outerMaxIter, outerTol, qpMaxIter, qpTol)
+}
+
 updateBeta <- function(beta, Qinv_ii, Qinv_beta, s, lambda, p) {
     invisible(.Call(`_pcglassoFast_updateBeta`, beta, Qinv_ii, Qinv_beta, s, lambda, p))
 }

--- a/R/pcglassoFast.R
+++ b/R/pcglassoFast.R
@@ -362,30 +362,111 @@ R_step_primalDual <- function(C, D, lambda, alpha, R_curr, R_inv_curr, tolerance
   S_for_primal_dual <- C * (D %o% D)
   max_iter_R_outer_curr <- min(max_iter_R_outer, max(2L, max_iter_R))
 
-  resR <- ROptimPrimalDual(
-    S = S_for_primal_dual,
-    R = R_curr,
-    U = R_dual_box_curr,
-    lambda = lambda,
-    outer.Maxiter = max_iter_R_outer_curr,
-    outer.tol = tol_R_curr,
-    qp.Maxiter = max_iter_R,
-    qp.tol = 1e-7,
-    obj.seq = FALSE,
-    stopping.rule = "max",
-    track.qp.time = FALSE
-  )
+  iterations_in_R_done <- -1
+  iterations_in_dual_done <- 0
 
-  if ((!is.null(resR$Rinv) && any(is.nan(resR$Rinv))) | any(is.nan(resR$R_symetric))) {
-    warn("NaNs introduced in primal-dual calculations")
-    return()
-  }
+  repeat {
+    iterations_in_R_done <- iterations_in_R_done + 1
 
-  proposed_objective <- function_to_optimize(resR$R_symetric, D, C, lambda, alpha)
-  iterations_done <- resR$outer.count
+    if (verbose >= 5) {
+      print("=== R step (Primal-Dual) ===")
+      print(paste0("tol_R_curr = ", tol_R_curr))
+      print(paste0("outer.Maxiter = ", max_iter_R_outer_curr))
+    }
 
-  if (verbose >= 2) {
-    print(paste0("Iteration ", iteration_number, ". Objective: ", round(proposed_objective, digits_to_print), ". Objective diff: ", round(proposed_objective - prev_objective, digits_to_print), ", after ", iterations_done, " iters of R optim"))
+    resR <- ROptimPrimalDual(
+      S = S_for_primal_dual,
+      R = R_curr,
+      U = R_dual_box_curr,
+      lambda = lambda,
+      outer.Maxiter = max_iter_R_outer_curr,
+      outer.tol = tol_R_curr,
+      qp.Maxiter = max_iter_R,
+      qp.tol = 1e-7,
+      obj.seq = FALSE,
+      stopping.rule = "max",
+      track.qp.time = FALSE
+    )
+
+    if ((!is.null(resR$Rinv) && any(is.nan(resR$Rinv))) | any(is.nan(resR$R_symetric))) {
+      warn("NaNs introduced in primal-dual calculations")
+      return()
+    }
+
+    proposed_objective <- function_to_optimize(resR$R_symetric, D, C, lambda, alpha)
+    iterations_in_dual_done <- iterations_in_dual_done + resR$outer.count
+
+    if (verbose >= 5) {
+      print("=== After R step (Primal-Dual) ===")
+      print(paste0("objective: ", round(proposed_objective, digits_to_print)))
+    }
+
+    # Check if objective improved
+    objective_is_better <- (proposed_objective > prev_objective - tolerance_full_optimization * 0.1)
+
+    # Check if R is positive definite
+    smallest_eigen_value <- eigen(resR$R_symetric, TRUE, TRUE)$values[p]
+    R_positive_definite <- (smallest_eigen_value > 0)
+
+    if (objective_is_better & R_positive_definite) {
+      # Success: objective improved and R is valid
+      if (verbose >= 2) {
+        print(paste0("Iteration ", iteration_number, ". Objective: ", round(proposed_objective, digits_to_print), ". Objective diff: ", round(proposed_objective - prev_objective, digits_to_print), ", after ", iterations_in_dual_done, " iters of R optim"))
+      }
+      break  # ← EXIT repeat loop
+    }
+
+    # Diagnose why continuing
+    if (verbose >= 4) {
+      print(paste0(
+        "Continue R optimization as ",
+        if (!objective_is_better) {
+          paste0("objective has not yet improved (objective = ",
+                 round(proposed_objective, digits_to_print),
+                 " prev objective = ", round(prev_objective, digits_to_print), ")")
+        } else {
+          paste0("R matrix was not positive definite (eigen value ",
+                 round(smallest_eigen_value, digits_to_print), ")")
+        }))
+    }
+
+    # Check iteration limit
+    if (iterations_in_R_done >= max_iter_R) {
+      if (verbose >= 2) {
+        print("Ending primal-dual R optimization at max_iter_R")
+      }
+
+      if (!R_positive_definite) {
+        # Force R to be positive definite
+        warn(paste0("Primal-dual R optimization resulted in non-positive definite matrix"))
+        desired_smallest_eigen_value <- 0.01
+        x <- (1 - desired_smallest_eigen_value) / (1 - smallest_eigen_value)
+        resR$R_symetric <- x * resR$R_symetric + diag(1 - x, p)
+        proposed_objective <- function_to_optimize(resR$R_symetric, D, C, lambda, alpha)
+      }
+      break  # EXIT repeat loop
+    }
+
+    # Adapt tolerance strategy
+    if (resR$outer.count < max_iter_R_outer_curr) {
+      # Primal-dual solver had room to spare -> tighten tolerance
+      new_tol_R_curr <- max(tol_R_curr / times_tol_R_decrease, tol_R)
+      if ((verbose >= 4) & (new_tol_R_curr < tol_R_curr)) {
+        print(paste0("Decreasing tol_R_curr to ", new_tol_R_curr))
+      }
+      tol_R_curr <- new_tol_R_curr
+    } else {
+      # Primal-dual solver hit its limit -> increase budget
+      new_max_iter_R_outer_curr <- min(max_iter_R_outer_curr * 10, max_iter_R_outer)
+      if ((verbose >= 4) & (max_iter_R_outer_curr < new_max_iter_R_outer_curr)) {
+        print(paste0("Increasing max_iter_R_outer_curr to ", new_max_iter_R_outer_curr))
+      }
+      max_iter_R_outer_curr <- new_max_iter_R_outer_curr
+    }
+
+    # Update state & retry
+    R_curr <- resR$R_symetric
+    R_dual_box_curr <- resR$dual_box
   }
 
   list(
@@ -394,7 +475,7 @@ R_step_primalDual <- function(C, D, lambda, alpha, R_curr, R_inv_curr, tolerance
     R_inv = resR$Rinv,
     dual_box = resR$dual_box,
     proposed_objective = proposed_objective,
-    iterations_done = iterations_done
+    iterations_done = iterations_in_dual_done
   )
 }
 

--- a/R/pcglassoFast.R
+++ b/R/pcglassoFast.R
@@ -99,6 +99,7 @@ pcglassoFast <- function(
   D <- D0 * sqrt(diag(S))
   R <- R0
   R_inv <- R0_inv
+  R_dual_box <- NULL
   C <- cov2cor(S)
   strating_time <- Sys.time()
   digits_to_print <- max(0, -floor(log10(tolerance)))
@@ -162,7 +163,22 @@ pcglassoFast <- function(
       "primal" = R_step_primal,
       "primal_dual" = R_step_primalDual
     )
-    R_result <- R_step(C, D, lambda, alpha, R, R_inv, tolerance, times_tol_R_decrease, tol_R, tol_R_curr, max_iter_R, max_iter_R_outer, objective_history[length(objective_history)], verbose, length(objective_history)/2)
+    if (solver_R == "primal_dual") {
+      R_result <- R_step(
+        C, D, lambda, alpha, R, R_inv, tolerance, times_tol_R_decrease,
+        tol_R, tol_R_curr, max_iter_R, max_iter_R_outer,
+        objective_history[length(objective_history)], verbose,
+        length(objective_history) / 2,
+        R_dual_box_curr = R_dual_box
+      )
+    } else {
+      R_result <- R_step(
+        C, D, lambda, alpha, R, R_inv, tolerance, times_tol_R_decrease,
+        tol_R, tol_R_curr, max_iter_R, max_iter_R_outer,
+        objective_history[length(objective_history)], verbose,
+        length(objective_history) / 2
+      )
+    }
 
     R_optimizaiton_improved_objective <- (R_result$proposed_objective - objective_history[length(objective_history)] > -2 * tolerance)
     if (!R_optimizaiton_improved_objective) {
@@ -176,6 +192,7 @@ pcglassoFast <- function(
     R <- R_result$R
     R_symetric <- R_result$R_symetric
     R_inv <- R_result$R_inv
+    R_dual_box <- if (solver_R == "primal_dual") R_result$dual_box else NULL
     improvement_R <- R_result$proposed_objective - objective_history[length(objective_history)]
     objective_history <- c(objective_history, R_result$proposed_objective)
 
@@ -338,25 +355,28 @@ R_step_dual <- function(C, D, lambda, alpha, R_curr, R_inv_curr, tolerance_full_
 }
 
 
-R_step_primalDual <- function(C, D, lambda, alpha, R_curr, R_inv_curr, tolerance_full_optimization, times_tol_R_decrease, tol_R, tol_R_curr, max_iter_R, max_iter_R_outer, prev_objective, verbose, iteration_number) {
+R_step_primalDual <- function(C, D, lambda, alpha, R_curr, R_inv_curr, tolerance_full_optimization, times_tol_R_decrease, tol_R, tol_R_curr, max_iter_R, max_iter_R_outer, prev_objective, verbose, iteration_number, R_dual_box_curr = NULL) {
   digits_to_print <- max(0, -floor(log10(tolerance_full_optimization)))
   p <- dim(C)[1]
 
   S_for_primal_dual <- C * (D %o% D)
+  max_iter_R_outer_curr <- min(max_iter_R_outer, max(2L, max_iter_R))
 
   resR <- ROptimPrimalDual(
     S = S_for_primal_dual,
     R = R_curr,
-    U = NULL,
+    U = R_dual_box_curr,
     lambda = lambda,
-    outer.Maxiter = max_iter_R_outer,
+    outer.Maxiter = max_iter_R_outer_curr,
     outer.tol = tol_R_curr,
     qp.Maxiter = max_iter_R,
     qp.tol = 1e-7,
-    obj.seq = FALSE
+    obj.seq = FALSE,
+    stopping.rule = "max",
+    track.qp.time = FALSE
   )
 
-  if (any(is.nan(resR$Rinv)) | any(is.nan(resR$R_symetric))) {
+  if ((!is.null(resR$Rinv) && any(is.nan(resR$Rinv))) | any(is.nan(resR$R_symetric))) {
     warn("NaNs introduced in primal-dual calculations")
     return()
   }
@@ -372,6 +392,7 @@ R_step_primalDual <- function(C, D, lambda, alpha, R_curr, R_inv_curr, tolerance
     R = resR$R_symetric,
     R_symetric = resR$R_symetric,
     R_inv = resR$Rinv,
+    dual_box = resR$dual_box,
     proposed_objective = proposed_objective,
     iterations_done = iterations_done
   )

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -28,6 +28,56 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// boxQpCpp
+Rcpp::List boxQpCpp(const arma::mat& Q, arma::vec u, const arma::vec& b, double rho, int maxIter, double tol);
+RcppExport SEXP _pcglassoFast_boxQpCpp(SEXP QSEXP, SEXP uSEXP, SEXP bSEXP, SEXP rhoSEXP, SEXP maxIterSEXP, SEXP tolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::mat& >::type Q(QSEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type u(uSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type b(bSEXP);
+    Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
+    Rcpp::traits::input_parameter< int >::type maxIter(maxIterSEXP);
+    Rcpp::traits::input_parameter< double >::type tol(tolSEXP);
+    rcpp_result_gen = Rcpp::wrap(boxQpCpp(Q, u, b, rho, maxIter, tol));
+    return rcpp_result_gen;
+END_RCPP
+}
+// primalDualSweepCpp
+Rcpp::List primalDualSweepCpp(const arma::mat& S, arma::mat R, arma::mat U, double lambda, int qpMaxIter, double qpTol);
+RcppExport SEXP _pcglassoFast_primalDualSweepCpp(SEXP SSEXP, SEXP RSEXP, SEXP USEXP, SEXP lambdaSEXP, SEXP qpMaxIterSEXP, SEXP qpTolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::mat& >::type S(SSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type R(RSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type U(USEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< int >::type qpMaxIter(qpMaxIterSEXP);
+    Rcpp::traits::input_parameter< double >::type qpTol(qpTolSEXP);
+    rcpp_result_gen = Rcpp::wrap(primalDualSweepCpp(S, R, U, lambda, qpMaxIter, qpTol));
+    return rcpp_result_gen;
+END_RCPP
+}
+// primalDualOuterCpp
+Rcpp::List primalDualOuterCpp(const arma::mat& S, arma::mat R, arma::mat U, double lambda, int outerMaxIter, double outerTol, int qpMaxIter, double qpTol);
+RcppExport SEXP _pcglassoFast_primalDualOuterCpp(SEXP SSEXP, SEXP RSEXP, SEXP USEXP, SEXP lambdaSEXP, SEXP outerMaxIterSEXP, SEXP outerTolSEXP, SEXP qpMaxIterSEXP, SEXP qpTolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::mat& >::type S(SSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type R(RSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type U(USEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< int >::type outerMaxIter(outerMaxIterSEXP);
+    Rcpp::traits::input_parameter< double >::type outerTol(outerTolSEXP);
+    Rcpp::traits::input_parameter< int >::type qpMaxIter(qpMaxIterSEXP);
+    Rcpp::traits::input_parameter< double >::type qpTol(qpTolSEXP);
+    rcpp_result_gen = Rcpp::wrap(primalDualOuterCpp(S, R, U, lambda, outerMaxIter, outerTol, qpMaxIter, qpTol));
+    return rcpp_result_gen;
+END_RCPP
+}
 // updateBeta
 void updateBeta(arma::vec& beta, const arma::mat& Qinv_ii, arma::vec& Qinv_beta, const arma::vec& s, double lambda, int p);
 RcppExport SEXP _pcglassoFast_updateBeta(SEXP betaSEXP, SEXP Qinv_iiSEXP, SEXP Qinv_betaSEXP, SEXP sSEXP, SEXP lambdaSEXP, SEXP pSEXP) {

--- a/src/box_qp_cpp.cpp
+++ b/src/box_qp_cpp.cpp
@@ -1,0 +1,232 @@
+#include <RcppArmadillo.h>
+#include <algorithm>
+#include <cmath>
+
+// [[Rcpp::depends(RcppArmadillo)]]
+
+namespace {
+
+void box_qp_dense(
+    const arma::mat& Q,
+    arma::vec& u,
+    const arma::vec& b,
+    const double rho,
+    const int maxIter,
+    const double tol,
+    arma::vec& grad) {
+  grad = 2.0 * Q * (u + b);
+  double objcur = arma::dot(grad, b + u);
+  double objold = objcur;
+
+  for (int outer = 1; outer <= maxIter; ++outer) {
+    for (arma::uword col = 0; col < Q.n_rows; ++col) {
+      const double uold = u[col];
+      const double diag = Q(col, col);
+      const double bb = grad[col] - 2.0 * diag * u[col];
+      const double tt = std::abs(bb) / (2.0 * diag);
+      u[col] = std::copysign(std::min(tt, rho), -bb);
+
+      if (u[col] != uold) {
+        grad += 2.0 * (u[col] - uold) * Q.col(col);
+      }
+    }
+
+    objcur = arma::dot(grad, b + u);
+    const double dlx = std::abs(objcur - objold) / (std::abs(objold) + 1e-6);
+    objold = objcur;
+    if (dlx < tol || outer > maxIter - 1) break;
+  }
+}
+
+void box_qp_full_without_column(
+    const arma::mat& R,
+    const arma::subview_col<double>& b,
+    arma::vec& u,
+    const arma::uword skipped,
+    const double rho,
+    const int maxIter,
+    const double tol,
+    arma::vec& grad,
+    arma::vec& z) {
+  z = u;
+  z += b;
+  z[skipped] = 0.0;
+  u[skipped] = 0.0;
+
+  grad = 2.0 * R * z;
+  double objcur = arma::dot(grad, z);
+  double objold = objcur;
+
+  for (int outer = 1; outer <= maxIter; ++outer) {
+    for (arma::uword col = 0; col < R.n_rows; ++col) {
+      if (col == skipped) continue;
+
+      const double uold = u[col];
+      const double diag = R(col, col);
+      const double bb = grad[col] - 2.0 * diag * u[col];
+      const double tt = std::abs(bb) / (2.0 * diag);
+      u[col] = std::copysign(std::min(tt, rho), -bb);
+
+      if (u[col] != uold) {
+        const double update = u[col] - uold;
+        z[col] += update;
+        grad += 2.0 * update * R.col(col);
+      }
+    }
+
+    objcur = arma::dot(grad, z);
+    const double dlx = std::abs(objcur - objold) / (std::abs(objold) + 1e-6);
+    objold = objcur;
+    if (dlx < tol || outer > maxIter - 1) break;
+  }
+}
+
+void primal_dual_sweep_inplace(
+    const arma::mat& S,
+    arma::mat& R,
+    arma::mat& U,
+    const double lambda,
+    const int qpMaxIter,
+    const double qpTol) {
+  const arma::uword p = R.n_rows;
+  arma::vec u(p);
+  arma::vec grad;
+  arma::vec z(p);
+
+  for (arma::uword j = 0; j < p; ++j) {
+    u = U.col(j);
+    box_qp_full_without_column(
+      R, S.col(j), u, j, lambda, qpMaxIter, qpTol, grad, z
+    );
+
+    const double tval = arma::dot(z, 0.5 * grad);
+    const double disc = 1.0 + 4.0 * tval;
+    if (disc <= 0.0) {
+      Rcpp::stop("PCGLASSO block update produced a non-positive discriminant.");
+    }
+
+    const double omega = (1.0 + std::sqrt(disc)) / 2.0;
+    for (arma::uword row = 0; row < p; ++row) {
+      if (row == j) continue;
+      const double r = -0.5 * grad[row] / omega;
+      R(row, j) = r;
+      R(j, row) = r;
+      U(row, j) = u[row];
+      U(j, row) = u[row];
+    }
+
+    R(j, j) = 1.0;
+    U(j, j) = 0.0;
+  }
+}
+
+void summarize_outer_change(
+    const arma::mat& R,
+    const arma::mat& R_old,
+    double& max_change,
+    double& rms_change,
+    double& sparse_nos) {
+  const arma::uword p = R.n_rows;
+  double max_abs_old = 1.0;
+  double max_abs_diff = 0.0;
+  double sum_sq_offdiag = 0.0;
+  double sparse_count = 0.0;
+
+  for (arma::uword col = 0; col < p; ++col) {
+    for (arma::uword row = 0; row < p; ++row) {
+      max_abs_old = std::max(max_abs_old, std::abs(R_old(row, col)));
+      max_abs_diff = std::max(max_abs_diff, std::abs(R(row, col) - R_old(row, col)));
+      if (row != col) {
+        const double diff = R(row, col) - R_old(row, col);
+        sum_sq_offdiag += diff * diff;
+        if (std::abs(R(row, col)) <= 1e-9) {
+          sparse_count += 1.0;
+        }
+      }
+    }
+  }
+
+  max_change = max_abs_diff / max_abs_old;
+  rms_change = std::sqrt(sum_sq_offdiag / static_cast<double>(p * (p - 1)));
+  sparse_nos = sparse_count;
+}
+
+} // namespace
+
+// [[Rcpp::export]]
+Rcpp::List boxQpCpp(
+    const arma::mat& Q,
+    arma::vec u,
+    const arma::vec& b,
+    double rho,
+    int maxIter,
+    double tol) {
+  arma::vec grad;
+  box_qp_dense(Q, u, b, rho, maxIter, tol, grad);
+
+  return Rcpp::List::create(
+    Rcpp::Named("grad_vec") = grad,
+    Rcpp::Named("u") = u
+  );
+}
+
+// [[Rcpp::export]]
+Rcpp::List primalDualSweepCpp(
+    const arma::mat& S,
+    arma::mat R,
+    arma::mat U,
+    double lambda,
+    int qpMaxIter,
+    double qpTol) {
+  primal_dual_sweep_inplace(S, R, U, lambda, qpMaxIter, qpTol);
+
+  return Rcpp::List::create(
+    Rcpp::Named("R") = R,
+    Rcpp::Named("U") = U
+  );
+}
+
+// [[Rcpp::export]]
+Rcpp::List primalDualOuterCpp(
+    const arma::mat& S,
+    arma::mat R,
+    arma::mat U,
+    double lambda,
+    int outerMaxIter,
+    double outerTol,
+    int qpMaxIter,
+    double qpTol) {
+  arma::vec rel_err(outerMaxIter);
+  arma::vec rms_err(outerMaxIter);
+  arma::vec sparse_nos(outerMaxIter);
+  arma::mat R_old(R.n_rows, R.n_cols);
+  int outer_count = outerMaxIter;
+
+  for (int outer = 0; outer < outerMaxIter; ++outer) {
+    R_old = R;
+    primal_dual_sweep_inplace(S, R, U, lambda, qpMaxIter, qpTol);
+
+    double max_change = 0.0;
+    double rms_change = 0.0;
+    double sparse_count = 0.0;
+    summarize_outer_change(R, R_old, max_change, rms_change, sparse_count);
+
+    rel_err[outer] = max_change;
+    rms_err[outer] = rms_change;
+    sparse_nos[outer] = sparse_count;
+
+    if (outer > 0 && max_change < outerTol) {
+      outer_count = outer + 1;
+      break;
+    }
+  }
+
+  return Rcpp::List::create(
+    Rcpp::Named("R") = R,
+    Rcpp::Named("U") = U,
+    Rcpp::Named("outer.count") = outer_count,
+    Rcpp::Named("rel.err") = rel_err.subvec(0, outer_count - 1),
+    Rcpp::Named("rms.err") = rms_err.subvec(0, outer_count - 1),
+    Rcpp::Named("sparse.nos") = sparse_nos.subvec(0, outer_count - 1)
+  );
+}

--- a/src/init.c
+++ b/src/init.c
@@ -7,6 +7,9 @@
 extern SEXP _pcglassoFast_Qinv_down_cpp(void *, void *);
 extern SEXP _pcglassoFast_Qinv_down_subet(void *, void *, void *);
 extern SEXP _pcglassoFast_Qinv_up_cpp(void *, void *, void *, void *);
+extern SEXP _pcglassoFast_boxQpCpp(void *, void *, void *, void *, void *, void *);
+extern SEXP _pcglassoFast_primalDualOuterCpp(void *, void *, void *, void *, void *, void *, void *, void *);
+extern SEXP _pcglassoFast_primalDualSweepCpp(void *, void *, void *, void *, void *, void *);
 extern SEXP _pcglassoFast_updateBeta(void *, void *, void *, void *, void *, void *);
 extern SEXP _pcglassoFast_updateLoopCpp(void *, void *, void *, void *, void *, void *, void *);
 
@@ -18,6 +21,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_pcglassoFast_Qinv_down_cpp",   (DL_FUNC) &_pcglassoFast_Qinv_down_cpp,   2},
     {"_pcglassoFast_Qinv_down_subet", (DL_FUNC) &_pcglassoFast_Qinv_down_subet, 3},
     {"_pcglassoFast_Qinv_up_cpp",     (DL_FUNC) &_pcglassoFast_Qinv_up_cpp,     4},
+    {"_pcglassoFast_boxQpCpp",        (DL_FUNC) &_pcglassoFast_boxQpCpp,        6},
+    {"_pcglassoFast_primalDualOuterCpp", (DL_FUNC) &_pcglassoFast_primalDualOuterCpp, 8},
+    {"_pcglassoFast_primalDualSweepCpp", (DL_FUNC) &_pcglassoFast_primalDualSweepCpp, 6},
     {"_pcglassoFast_updateBeta",      (DL_FUNC) &_pcglassoFast_updateBeta,      6},
     {"_pcglassoFast_updateLoopCpp",   (DL_FUNC) &_pcglassoFast_updateLoopCpp,   7},
     {NULL, NULL, 0}


### PR DESCRIPTION
## Summary
- move PrimalDual box-QP updates into Rcpp/Armadillo
- keep the standard PrimalDual outer loop in C++ for the production path
- warm-start the PrimalDual dual box variable across top-level pcglassoFast iterations
- avoid copying R[-j, -j] by using full-vector QP updates that skip the active coordinate

## Validation
- sweep and outer-loop equivalence checks against the previous reduced-QP path
- Appendix-style comparison with M=2, p=c(20,100)
- tests/fortran.R
- R CMD check --no-manual, status: 6 pre-existing warnings